### PR TITLE
chore: rebrand package ID to team.squill.powerflix

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace = "dev.davidgaspar.powerflix"
+    namespace = "team.squill.powerflix"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -20,7 +20,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "dev.davidgaspar.powerflix"
+        applicationId = "team.squill.powerflix"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/kotlin/team/squill/powerflix/MainActivity.kt
+++ b/android/app/src/main/kotlin/team/squill/powerflix/MainActivity.kt
@@ -1,4 +1,4 @@
-package dev.davidgaspar.powerflix
+package team.squill.powerflix
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.davidgaspar.powerflix;
+				PRODUCT_BUNDLE_IDENTIFIER = team.squill.powerflix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -452,7 +452,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.davidgaspar.powerflix;
+				PRODUCT_BUNDLE_IDENTIFIER = team.squill.powerflix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -472,7 +472,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.davidgaspar.powerflix;
+				PRODUCT_BUNDLE_IDENTIFIER = team.squill.powerflix;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
## Summary

- Updated Android `namespace` and `applicationId` in `build.gradle.kts`
- Moved `MainActivity.kt` from `dev/davidgaspar/powerflix/` to `team/squill/powerflix/` and updated its package declaration
- Updated all 3 `PRODUCT_BUNDLE_IDENTIFIER` entries in `ios/Runner.xcodeproj/project.pbxproj`

## Test plan

- [x] `flutter test` — 7/7 tests passed
- [x] `flutter build apk --debug` — Android build succeeded
- [x] `flutter build ios --debug --no-codesign` — iOS build succeeded with new bundle ID `team.squill.powerflix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)