### PR TITLE
chore: Add GitHub Packages publish workflow on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Build & publish Android release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Extract version from pubspec.yaml
+        id: version
+        run: |
+          echo "value=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)" >> $GITHUB_OUTPUT
+
+      - name: Build Android release APK
+        run: flutter build apk --release
+
+      - name: Publish to GitHub Packages
+        run: ./gradlew publish
+        working-directory: android
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          APP_VERSION: ${{ steps.version.outputs.value }}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     // The Flutter Gradle Plugin must be applied after the Android plugin.
     id("dev.flutter.flutter-gradle-plugin")
+    id("maven-publish")
 }
 
 android {
@@ -40,4 +41,29 @@ android {
 
 flutter {
     source = "../.."
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                groupId = "team.squill"
+                artifactId = "powerflix"
+                version = System.getenv("APP_VERSION") ?: android.defaultConfig.versionName!!
+                artifact(rootProject.file("../build/app/outputs/flutter-apk/app-release.apk")) {
+                    extension = "apk"
+                }
+            }
+        }
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/squillteam/powerflix-native")
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR") ?: ""
+                    password = System.getenv("GITHUB_TOKEN") ?: ""
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements **Option 2 — GitHub Actions with `GITHUB_TOKEN`** for publishing to GitHub Packages (Maven).

### What triggers it

```
push → main
```

Qualquer merge em `main` (via `release/vX.X.X` ou `hotfix/*`, conforme Gitflow) dispara o pipeline.

### Pipeline steps

| Step | What it does |
|---|---|
| Setup Java 17 + Flutter stable | Prepara o ambiente |
| `flutter test` | Garante que nenhum teste quebrado chega ao artefato publicado |
| Extract version | Lê `version:` do `pubspec.yaml` (ex: `1.0.0`) |
| `flutter build apk --release` | Gera `build/app/outputs/flutter-apk/app-release.apk` |
| `./gradlew publish` | Publica o APK no GitHub Packages via `maven-publish` |

### Maven coordinates

```
group:    team.squill
artifact: powerflix
version:  <from pubspec.yaml>
```

Artefato disponível em:
```
https://maven.pkg.github.com/squillteam/powerflix-native
```

### Changes

- `.github/workflows/publish.yml` — novo workflow
- `android/app/build.gradle.kts` — plugin `maven-publish` + bloco `afterEvaluate` com publicação configurada

### Permissions

O workflow usa apenas `GITHUB_TOKEN` gerado automaticamente pelo Actions — nenhum secret manual necessário.

```yaml
permissions:
  contents: read
  packages: write
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)