### PR TITLE
feat: Interactive muscle map with SVG rendering and stress tracking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,71 @@
+## 🎯 Why?
+
+> Describe the problem being solved and why this change is necessary.
+
+## 🏷️ Type of Change
+
+- [ ] 🐞 Bugfix (non-breaking change that fixes an issue)
+- [ ] 💚 Improvement (non-breaking change that adds/modifies features to existing functionality)
+- [ ] ⚡️ New feature (non-breaking change that adds functionality)
+- [ ] ⚠️ Breaking change (change that is not backwards compatible and/or changes current functionality)
+
+## 📦 What Changed?
+
+> Describe the layers, classes, entities, etc. that the PR modifies.
+> If possible, add details about how it was implemented, attaching screenshots or designs for better understanding.
+
+---
+
+## 📷 Screenshots *(required for UI changes)*
+
+| Before   | After   |
+|----------|---------|
+| Image    | Image   |
+
+## 🧪 Testing *(required for code changes)*
+
+### 📱 Platforms Tested
+
+- [ ] 🤖 Android
+- [ ] 🍎 iOS
+- [ ] 🌐 Web
+- [ ] 🖥️ Desktop
+
+### ✔️ Verification
+
+- [ ] Unit tests pass
+- [ ] Widget tests pass
+- [ ] Integration tests pass
+- [ ] Manual testing completed
+
+### 📝 Test Scenarios
+
+> Describe what you manually verified.
+
+## 🔗 Reference Links *(optional)*
+
+> Documentation links, Figma, Jira tasks, etc.
+
+## 🔄 Dependencies *(optional)*
+
+> List related PRs, backend changes, feature flags, migrations, or deployment requirements.
+
+---
+
+## ✅ Checklist
+
+- [ ] Self-review completed
+- [ ] Tests added/updated
+- [ ] Documentation updated (if needed)
+- [ ] Labels added
+- [ ] Reviewers assigned
+
+## 🔀 Merge Rules
+
+|            Pull Request            |  Merge Type  |
+|:----------------------------------:|:------------:|
+|    *feature/fix/etc* → develop     | SQUASH MERGE |
+| *feature/hotfix/fix/etc* → release | SQUASH MERGE |
+|          *hotfix* → main           | SQUASH MERGE |
+|          *release* → main          | MERGE COMMIT |
+|        *backport* → develop        | MERGE COMMIT |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,20 @@ Rules:
 
 The data layer sits between the ViewModel and the actual storage. Its job is to keep the ViewModel **testable** by hiding implementation details behind interfaces.
 
+### Domain vs Data
+
+`domain` defines **what** — contracts and models that are agnostic to any technology or framework.
+
+`data` is the **infrastructure layer**. It defines **how** — it implements the domain contracts using real technical code (HTTP clients, Hive, SQLite, asset bundles).
+
+The dependency is strictly one-directional:
+
+```
+presentation → domain ← data
+```
+
+`data` knows `domain` (it implements its interfaces), but `domain` never knows `data`. This isolation means you can replace Hive with SQLite, or swap a local datasource for a remote API, without touching the domain or presentation layers.
+
 ### Components
 
 ```mermaid

--- a/lib/core/domain/models/muscle_stress.dart
+++ b/lib/core/domain/models/muscle_stress.dart
@@ -1,0 +1,8 @@
+enum MuscleStress { none, low, medium, high }
+
+extension MuscleStressExtension on MuscleStress {
+  MuscleStress get next {
+    const cycle = MuscleStress.values;
+    return cycle[(index + 1) % cycle.length];
+  }
+}

--- a/lib/features/muscle_map/data/datasources/muscle_map_asset_datasource.dart
+++ b/lib/features/muscle_map/data/datasources/muscle_map_asset_datasource.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/services.dart';
+import 'package:path_drawing/path_drawing.dart';
+import 'package:powerflix/features/muscle_map/data/datasources/muscle_map_datasource.dart';
+import 'package:powerflix/features/muscle_map/domain/models/muscle_path_data.dart';
+import 'package:xml/xml.dart';
+
+class MuscleMapAssetDatasource implements MuscleMapDatasource {
+  static const _frontAsset = 'assets/image/svg/male_muscle_map_front.svg';
+  static const _backAsset = 'assets/image/svg/male_muscle_map_back.svg';
+
+  final AssetBundle _bundle;
+
+  MuscleMapAssetDatasource({AssetBundle? bundle})
+      : _bundle = bundle ?? rootBundle;
+
+  @override
+  Future<List<MusclePathData>> fetchPaths({required bool isFront}) async {
+    final raw = await _bundle.loadString(isFront ? _frontAsset : _backAsset);
+    return _parse(raw);
+  }
+
+  List<MusclePathData> _parse(String svg) {
+    final doc = XmlDocument.parse(svg);
+    final result = <MusclePathData>[];
+
+    for (final el in doc.findAllElements('path')) {
+      final id = el.getAttribute('id');
+      final d = el.getAttribute('d');
+      if (id == null || !id.startsWith('muscle_') || d == null) continue;
+
+      final path = parseSvgPathData(d);
+      // SVG uses a flipped Y axis relative to Flutter's canvas; fillType
+      // defaults to nonZero which matches SVG's fill-rule default.
+      result.add(MusclePathData(id: id, path: path));
+    }
+
+    return result;
+  }
+}

--- a/lib/features/muscle_map/data/datasources/muscle_map_datasource.dart
+++ b/lib/features/muscle_map/data/datasources/muscle_map_datasource.dart
@@ -1,0 +1,5 @@
+import 'package:powerflix/features/muscle_map/domain/models/muscle_path_data.dart';
+
+abstract class MuscleMapDatasource {
+  Future<List<MusclePathData>> fetchPaths({required bool isFront});
+}

--- a/lib/features/muscle_map/data/repositories/muscle_map_repository_impl.dart
+++ b/lib/features/muscle_map/data/repositories/muscle_map_repository_impl.dart
@@ -1,0 +1,13 @@
+import 'package:powerflix/features/muscle_map/data/datasources/muscle_map_datasource.dart';
+import 'package:powerflix/features/muscle_map/domain/models/muscle_path_data.dart';
+import 'package:powerflix/features/muscle_map/domain/repositories/muscle_map_repository.dart';
+
+class MuscleMapRepositoryImpl implements MuscleMapRepository {
+  final MuscleMapDatasource _datasource;
+
+  MuscleMapRepositoryImpl(this._datasource);
+
+  @override
+  Future<List<MusclePathData>> getPaths({required bool isFront}) =>
+      _datasource.fetchPaths(isFront: isFront);
+}

--- a/lib/features/muscle_map/domain/models/muscle_path_data.dart
+++ b/lib/features/muscle_map/domain/models/muscle_path_data.dart
@@ -1,0 +1,8 @@
+import 'dart:ui';
+
+class MusclePathData {
+  final String id;
+  final Path path;
+
+  const MusclePathData({required this.id, required this.path});
+}

--- a/lib/features/muscle_map/domain/repositories/muscle_map_repository.dart
+++ b/lib/features/muscle_map/domain/repositories/muscle_map_repository.dart
@@ -1,0 +1,5 @@
+import 'package:powerflix/features/muscle_map/domain/models/muscle_path_data.dart';
+
+abstract class MuscleMapRepository {
+  Future<List<MusclePathData>> getPaths({required bool isFront});
+}

--- a/lib/features/muscle_map/presentation/muscle_map_viewmodel.dart
+++ b/lib/features/muscle_map/presentation/muscle_map_viewmodel.dart
@@ -9,7 +9,7 @@ class MuscleMapViewModel extends ChangeNotifier {
   MuscleMapViewModel(this._repository);
 
   List<MusclePathData> _paths = [];
-  List<MusclePathData> get paths => _paths;
+  List<MusclePathData> get paths => List.unmodifiable(_paths);
 
   final Map<String, MuscleStress> _stress = {};
   Map<String, MuscleStress> get stress => Map.unmodifiable(_stress);

--- a/lib/features/muscle_map/presentation/muscle_map_viewmodel.dart
+++ b/lib/features/muscle_map/presentation/muscle_map_viewmodel.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:powerflix/core/domain/models/muscle_stress.dart';
+import 'package:powerflix/features/muscle_map/domain/models/muscle_path_data.dart';
+import 'package:powerflix/features/muscle_map/domain/repositories/muscle_map_repository.dart';
+
+class MuscleMapViewModel extends ChangeNotifier {
+  final MuscleMapRepository _repository;
+
+  MuscleMapViewModel(this._repository);
+
+  List<MusclePathData> _paths = [];
+  List<MusclePathData> get paths => _paths;
+
+  final Map<String, MuscleStress> _stress = {};
+  Map<String, MuscleStress> get stress => Map.unmodifiable(_stress);
+
+  bool _isFront = true;
+  bool get isFront => _isFront;
+
+  bool _isLoading = true;
+  bool get isLoading => _isLoading;
+
+  String? _error;
+  bool get hasError => _error != null;
+
+  Future<void> init() => _loadPaths();
+
+  Future<void> toggleSide() async {
+    _isFront = !_isFront;
+    await _loadPaths();
+  }
+
+  void onMuscleTap(String muscleId) {
+    final current = _stress[muscleId] ?? MuscleStress.none;
+    _stress[muscleId] = current.next;
+    notifyListeners();
+  }
+
+  Future<void> _loadPaths() async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _paths = await _repository.getPaths(isFront: _isFront);
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/muscle_map/presentation/muscle_map_widget.dart
+++ b/lib/features/muscle_map/presentation/muscle_map_widget.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:powerflix/features/muscle_map/data/datasources/muscle_map_asset_datasource.dart';
+import 'package:powerflix/features/muscle_map/data/repositories/muscle_map_repository_impl.dart';
+import 'package:powerflix/features/muscle_map/presentation/muscle_map_viewmodel.dart';
+import 'package:powerflix/features/muscle_map/presentation/widget/muscle_painter.dart';
+import 'package:powerflix/features/muscle_map/presentation/widget/muscle_side_toggle.dart';
+import 'package:powerflix/features/muscle_map/presentation/widget/stress_legend.dart';
+import 'package:powerflix/shared/widgets/loading.dart';
+
+class MuscleMapWidget extends StatefulWidget {
+  static const routeName = '/muscle_map';
+
+  const MuscleMapWidget({super.key});
+
+  @override
+  State<MuscleMapWidget> createState() => _MuscleMapWidgetState();
+}
+
+class _MuscleMapWidgetState extends State<MuscleMapWidget> {
+  late final MuscleMapViewModel _viewModel;
+
+  // Holds a reference to the painter so we can call hitTest from the
+  // GestureDetector without re-creating it on every frame.
+  MusclePainter? _painter;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = MuscleMapViewModel(
+      MuscleMapRepositoryImpl(MuscleMapAssetDatasource()),
+    );
+    _viewModel.init();
+  }
+
+  @override
+  void dispose() {
+    _viewModel.dispose();
+    super.dispose();
+  }
+
+  void _onTapUp(TapUpDetails details, Size canvasSize) {
+    final muscleId = _painter?.findMuscleAt(details.localPosition, canvasSize);
+    if (muscleId != null) _viewModel.onMuscleTap(muscleId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Muscle Map')),
+      body: ListenableBuilder(
+        listenable: _viewModel,
+        builder: (context, _) {
+          if (_viewModel.isLoading) return Loading();
+          if (_viewModel.hasError) {
+            return const Center(child: Text('Failed to load muscle map.'));
+          }
+          return _buildBody();
+        },
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    return Column(
+      children: [
+        const SizedBox(height: 16),
+        MuscleSideToggle(
+          isFront: _viewModel.isFront,
+          onToggle: _viewModel.toggleSide,
+        ),
+        const SizedBox(height: 12),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: AspectRatio(
+              aspectRatio: kMuscleMapAspectRatio,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final canvasSize = Size(
+                    constraints.maxWidth,
+                    constraints.maxHeight,
+                  );
+                  _painter = MusclePainter(
+                    paths: _viewModel.paths,
+                    stress: _viewModel.stress,
+                  );
+                  return GestureDetector(
+                    onTapUp: (d) => _onTapUp(d, canvasSize),
+                    child: CustomPaint(
+                      painter: _painter,
+                      size: canvasSize,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        const StressLegend(),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}

--- a/lib/features/muscle_map/presentation/muscle_map_widget.dart
+++ b/lib/features/muscle_map/presentation/muscle_map_widget.dart
@@ -50,7 +50,7 @@ class _MuscleMapWidgetState extends State<MuscleMapWidget> {
       body: ListenableBuilder(
         listenable: _viewModel,
         builder: (context, _) {
-          if (_viewModel.isLoading) return Loading();
+          if (_viewModel.isLoading) return const Loading();
           if (_viewModel.hasError) {
             return const Center(child: Text('Failed to load muscle map.'));
           }

--- a/lib/features/muscle_map/presentation/widget/muscle_painter.dart
+++ b/lib/features/muscle_map/presentation/widget/muscle_painter.dart
@@ -1,0 +1,68 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart' show Color, CustomPainter;
+import 'package:powerflix/core/domain/models/muscle_stress.dart';
+import 'package:powerflix/features/muscle_map/domain/models/muscle_path_data.dart';
+
+// SVG viewBox dimensions — both maps share the same canvas size.
+const double kMuscleMapWidth = 661.0;
+const double kMuscleMapHeight = 1207.0;
+const double kMuscleMapAspectRatio = kMuscleMapWidth / kMuscleMapHeight;
+
+class MusclePainter extends CustomPainter {
+  final List<MusclePathData> paths;
+  final Map<String, MuscleStress> stress;
+
+  const MusclePainter({required this.paths, required this.stress});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scale = size.width / kMuscleMapWidth;
+
+    canvas.save();
+    canvas.scale(scale);
+
+    for (final muscle in paths) {
+      final level = stress[muscle.id] ?? MuscleStress.none;
+
+      canvas.drawPath(muscle.path, Paint()
+        ..style = PaintingStyle.fill
+        ..color = _fillColor(level));
+
+      canvas.drawPath(muscle.path, Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.2 / scale
+        ..color = const Color(0x55000000));
+    }
+
+    canvas.restore();
+  }
+
+  // Returns the muscle hit at [tapPosition] in widget (scaled) coordinates,
+  // or null if no muscle was tapped.
+  String? findMuscleAt(Offset tapPosition, Size canvasSize) {
+    final scale = canvasSize.width / kMuscleMapWidth;
+    final svgPoint = tapPosition / scale;
+
+    // Iterate in reverse so top-rendered paths (drawn last) take priority.
+    for (final muscle in paths.reversed) {
+      if (muscle.path.contains(svgPoint)) return muscle.id;
+    }
+    return null;
+  }
+
+  static Color _fillColor(MuscleStress level) {
+    switch (level) {
+      case MuscleStress.none:   return const Color(0xFFBDBDBD);
+      case MuscleStress.low:    return const Color(0xFFFFEE58);
+      case MuscleStress.medium: return const Color(0xFFFF9800);
+      case MuscleStress.high:   return const Color(0xFFE53935);
+    }
+  }
+
+  static Color stressColor(MuscleStress level) => _fillColor(level);
+
+  @override
+  bool shouldRepaint(MusclePainter old) =>
+      old.paths != paths || old.stress != stress;
+}

--- a/lib/features/muscle_map/presentation/widget/muscle_side_toggle.dart
+++ b/lib/features/muscle_map/presentation/widget/muscle_side_toggle.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+class MuscleSideToggle extends StatelessWidget {
+  final bool isFront;
+  final VoidCallback onToggle;
+
+  const MuscleSideToggle({
+    required this.isFront,
+    required this.onToggle,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final active = theme.colorScheme.primary;
+    final inactive = theme.colorScheme.surfaceContainerHighest;
+
+    return GestureDetector(
+      onTap: onToggle,
+      child: Container(
+        decoration: BoxDecoration(
+          color: inactive,
+          borderRadius: BorderRadius.circular(24),
+        ),
+        padding: const EdgeInsets.all(4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _Tab(label: 'Front', active: isFront, activeColor: active),
+            _Tab(label: 'Back', active: !isFront, activeColor: active),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Tab extends StatelessWidget {
+  final String label;
+  final bool active;
+  final Color activeColor;
+
+  const _Tab({
+    required this.label,
+    required this.active,
+    required this.activeColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      decoration: BoxDecoration(
+        color: active ? activeColor : Colors.transparent,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: active ? Colors.white : Colors.grey,
+          fontWeight: FontWeight.w600,
+          fontSize: 13,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/muscle_map/presentation/widget/stress_legend.dart
+++ b/lib/features/muscle_map/presentation/widget/stress_legend.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:powerflix/core/domain/models/muscle_stress.dart';
+import 'package:powerflix/features/muscle_map/presentation/widget/muscle_painter.dart';
+
+class StressLegend extends StatelessWidget {
+  const StressLegend({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: MuscleStress.values
+          .where((s) => s != MuscleStress.none)
+          .map((s) => _LegendItem(level: s))
+          .toList(),
+    );
+  }
+}
+
+class _LegendItem extends StatelessWidget {
+  final MuscleStress level;
+
+  const _LegendItem({required this.level});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 12,
+            height: 12,
+            decoration: BoxDecoration(
+              color: MusclePainter.stressColor(level),
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            level.name[0].toUpperCase() + level.name.substring(1),
+            style: const TextStyle(fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:powerflix/app/databases/hive.dart';
 import 'package:powerflix/core/domain/models/workout_plan.dart';
+import 'package:powerflix/features/muscle_map/presentation/muscle_map_widget.dart';
 import 'package:powerflix/features/workout_detail/presentation/workout_detail_widget.dart';
 import 'package:powerflix/features/home/presentation/home_widget.dart';
 import 'package:powerflix/features/video/presentation/video_widget.dart';
@@ -51,6 +52,11 @@ class MyApp extends StatelessWidget {
             final link = settings.arguments as String;
             return MaterialPageRoute(
               builder: (_) => VideoWidget(link: link),
+            );
+
+          case MuscleMapWidget.routeName:
+            return MaterialPageRoute(
+              builder: (_) => const MuscleMapWidget(),
             );
 
           default:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -240,6 +240,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_drawing:
+    dependency: "direct main"
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -288,6 +304,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -453,6 +477,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: "direct main"
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,8 @@ dependencies:
   hive: ^2.2.3
   path_provider: ^2.1.5
   video_player: ^2.11.1
+  xml: ^6.5.0
+  path_drawing: ^1.0.1
 
 dev_dependencies:
   flutter_test:

--- a/test/features/muscle_map/muscle_map_viewmodel_test.dart
+++ b/test/features/muscle_map/muscle_map_viewmodel_test.dart
@@ -1,0 +1,160 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:powerflix/core/domain/models/muscle_stress.dart';
+import 'package:powerflix/features/muscle_map/domain/models/muscle_path_data.dart';
+import 'package:powerflix/features/muscle_map/domain/repositories/muscle_map_repository.dart';
+import 'package:powerflix/features/muscle_map/presentation/muscle_map_viewmodel.dart';
+
+// ── fakes ──────────────────────────────────────────────────────────────────
+
+class _FakeRepository implements MuscleMapRepository {
+  final List<MusclePathData> frontPaths;
+  final List<MusclePathData> backPaths;
+  int callCount = 0;
+
+  _FakeRepository({required this.frontPaths, required this.backPaths});
+
+  @override
+  Future<List<MusclePathData>> getPaths({required bool isFront}) async {
+    callCount++;
+    return isFront ? frontPaths : backPaths;
+  }
+}
+
+MusclePathData _fakePath(String id) =>
+    MusclePathData(id: id, path: Path());
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+void main() {
+  group('MuscleMapViewModel', () {
+    test('init loads front paths and clears loading state', () async {
+      final repo = _FakeRepository(
+        frontPaths: [_fakePath('muscle_chest')],
+        backPaths: [],
+      );
+      final vm = MuscleMapViewModel(repo);
+
+      expect(vm.isLoading, isTrue);
+
+      await vm.init();
+
+      expect(vm.isLoading, isFalse);
+      expect(vm.hasError, isFalse);
+      expect(vm.paths, hasLength(1));
+      expect(vm.paths.first.id, 'muscle_chest');
+      expect(vm.isFront, isTrue);
+    });
+
+    test('toggleSide switches to back and reloads paths', () async {
+      final repo = _FakeRepository(
+        frontPaths: [_fakePath('muscle_chest')],
+        backPaths: [_fakePath('muscle_trapezius'), _fakePath('muscle_lats')],
+      );
+      final vm = MuscleMapViewModel(repo);
+      await vm.init();
+
+      await vm.toggleSide();
+
+      expect(vm.isFront, isFalse);
+      expect(vm.paths, hasLength(2));
+      expect(vm.paths.first.id, 'muscle_trapezius');
+    });
+
+    test('toggleSide twice returns to front paths', () async {
+      final repo = _FakeRepository(
+        frontPaths: [_fakePath('muscle_chest')],
+        backPaths: [_fakePath('muscle_trapezius')],
+      );
+      final vm = MuscleMapViewModel(repo);
+      await vm.init();
+
+      await vm.toggleSide();
+      await vm.toggleSide();
+
+      expect(vm.isFront, isTrue);
+      expect(vm.paths.first.id, 'muscle_chest');
+    });
+
+    test('onMuscleTap cycles stress: none → low → medium → high → none', () async {
+      final repo = _FakeRepository(
+        frontPaths: [_fakePath('muscle_chest')],
+        backPaths: [],
+      );
+      final vm = MuscleMapViewModel(repo);
+      await vm.init();
+
+      expect(vm.stress['muscle_chest'], isNull);
+
+      vm.onMuscleTap('muscle_chest');
+      expect(vm.stress['muscle_chest'], MuscleStress.low);
+
+      vm.onMuscleTap('muscle_chest');
+      expect(vm.stress['muscle_chest'], MuscleStress.medium);
+
+      vm.onMuscleTap('muscle_chest');
+      expect(vm.stress['muscle_chest'], MuscleStress.high);
+
+      vm.onMuscleTap('muscle_chest');
+      expect(vm.stress['muscle_chest'], MuscleStress.none);
+    });
+
+    test('onMuscleTap on unknown id starts from none', () async {
+      final repo = _FakeRepository(frontPaths: [], backPaths: []);
+      final vm = MuscleMapViewModel(repo);
+      await vm.init();
+
+      vm.onMuscleTap('muscle_bicep');
+
+      expect(vm.stress['muscle_bicep'], MuscleStress.low);
+    });
+
+    test('stress is preserved across side toggle', () async {
+      final repo = _FakeRepository(
+        frontPaths: [_fakePath('muscle_chest')],
+        backPaths: [_fakePath('muscle_trapezius')],
+      );
+      final vm = MuscleMapViewModel(repo);
+      await vm.init();
+
+      vm.onMuscleTap('muscle_chest');
+      expect(vm.stress['muscle_chest'], MuscleStress.low);
+
+      await vm.toggleSide();
+
+      expect(vm.stress['muscle_chest'], MuscleStress.low);
+    });
+
+    test('notifyListeners is called after onMuscleTap', () async {
+      final repo = _FakeRepository(frontPaths: [], backPaths: []);
+      final vm = MuscleMapViewModel(repo);
+      await vm.init();
+
+      int notifyCount = 0;
+      vm.addListener(() => notifyCount++);
+
+      vm.onMuscleTap('muscle_chest');
+
+      expect(notifyCount, 1);
+    });
+
+    test('hasError is true when repository throws', () async {
+      final repo = _FailingRepository();
+      final vm = MuscleMapViewModel(repo);
+
+      await vm.init();
+
+      expect(vm.hasError, isTrue);
+      expect(vm.isLoading, isFalse);
+      expect(vm.paths, isEmpty);
+    });
+  });
+}
+
+class _FailingRepository implements MuscleMapRepository {
+  @override
+  Future<List<MusclePathData>> getPaths({required bool isFront}) async {
+    throw Exception('SVG load failed');
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a full muscle map feature (`/muscle_map` route) that renders front/back SVG body diagrams via `CustomPainter`
- Users tap any labeled muscle path to cycle its stress level: none → low → medium → high → none
- SVG paths are parsed at runtime with `xml` + `path_drawing`; hit-testing inverse-scales tap coordinates back to SVG space (661×1207 viewBox)
- `FrontBack` toggle animates between the two maps while preserving all stress state
- Full vertical slice: datasource → repository → viewmodel → painter + widget; 8 new unit tests for `MuscleMapViewModel`

## New packages
- `xml: ^6.5.0` — SVG XML parsing
- `path_drawing: ^1.0.1` — converts SVG `d` attribute to `dart:ui Path`

## Test plan
- [ ] `flutter test` — 61 tests, all passing
- [ ] `flutter analyze` — no issues
- [ ] Navigate to `/muscle_map`, tap muscles, verify stress colors cycle correctly
- [ ] Toggle Front/Back, verify paths reload and stress is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive muscle map feature with front and back anatomical views.
  * Implemented tap-to-track muscle stress level progression with visual indicators.
  * Added front/back view toggle for comprehensive muscle visualization.
  * Included stress level legend for easy reference during workouts.

* **Tests**
  * Added comprehensive test suite for muscle map functionality and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->